### PR TITLE
Euler co-routine can only be called once

### DIFF
--- a/Packages/com.caeden117.udoncoroutines/Runtime/Coroutines/Animations/Transforms/AnimateEulerAnglesCoroutine.cs
+++ b/Packages/com.caeden117.udoncoroutines/Runtime/Coroutines/Animations/Transforms/AnimateEulerAnglesCoroutine.cs
@@ -43,6 +43,7 @@ public class AnimateEulerAnglesCoroutine : AnimatedUdonCoroutine
 
     protected override void Setup()
     {
+        base.Setup();
         startRotation = Quaternion.Euler(start);
         endRotation = Quaternion.Euler(end);
     }


### PR DESCRIPTION
base.Setup() wasn't called in the inherited method meaning the progress wasn't reset resulting in a skip if you re-called StartCoroutine